### PR TITLE
Remove unused minimal-bootstrap-hugo-theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "themes/minimal-bootstrap-hugo-theme"]
-	path = themes/minimal-bootstrap-hugo-theme
-	url = https://github.com/zwbetz-gh/minimal-bootstrap-hugo-theme.git
 [submodule "public"]
 	path = public
 	url = git@github.com:sskelkar/sskelkar.github.io.git


### PR DESCRIPTION
Removed the minimal-bootstrap-hugo-theme submodule as it's not being used. The blog currently uses the beautifulhugo theme.