### PR TITLE
Add scroll padding for fixed navbar anchor links

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -45,6 +45,10 @@ body.dark-mode {
 
 /* --- General --- */
 
+html {
+  scroll-padding-top: 50px;
+}
+
 body {
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif;
   font-size: 16px;


### PR DESCRIPTION
## Summary

Add scroll-padding-top to fix anchor link scrolling being hidden behind fixed navbar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)